### PR TITLE
update to ubuntu18

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -15,7 +15,7 @@ RUN cd /tmp \
 	-Dcxx14=ON \
 	-Dfail-on-missing=OFF \
   -Druntime_cxxmodules=OFF \
-	-Dgnuinstall=ON \
+	-Dgnuinstall=OFF \
 	-Drpath=ON \
   -Droofit=ON \
   -Droostats=ON \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -14,6 +14,7 @@ RUN cd /tmp \
 	-Dall=ON \
 	-Dcxx14=ON \
 	-Dfail-on-missing=OFF \
+  -Druntime_cxxmodules=OFF \
 	-Dgnuinstall=ON \
 	-Drpath=ON \
   -Droofit=ON \
@@ -44,5 +45,5 @@ RUN cd /tmp \
  && cmake --build . --target install \
  && rm -rf /tmp/* /usr/src/root
 
-ENV PYTHONPATH /usr/local/lib
+ENV PYTHONPATH /usr/local/lib:/usr/local/lib/root
 CMD root -b

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -16,6 +16,9 @@ RUN cd /tmp \
 	-Dfail-on-missing=OFF \
 	-Dgnuinstall=ON \
 	-Drpath=ON \
+  -Droofit=ON \
+  -Droostats=ON \
+  -Dminuit2=ON \
 	-Dbuiltin_afterimage=OFF \
 	-Dbuiltin_ftgl=OFF \
 	-Dbuiltin_gl2ps=OFF \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:18.10
 
 COPY packages packages
 
@@ -13,7 +13,7 @@ RUN cd /tmp \
  && cmake /usr/src/root \
 	-Dall=ON \
 	-Dcxx14=ON \
-	-Dfail-on-missing=ON \
+	-Dfail-on-missing=OFF \
 	-Dgnuinstall=ON \
 	-Drpath=ON \
 	-Dbuiltin_afterimage=OFF \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -13,13 +13,13 @@ RUN cd /tmp \
  && cmake /usr/src/root \
 	-Dall=ON \
 	-Dcxx14=ON \
-	-Dfail-on-missing=OFF \
-  -Druntime_cxxmodules=OFF \
+	-Dfail-on-missing=ON \
+        -Druntime_cxxmodules=OFF \
 	-Dgnuinstall=OFF \
 	-Drpath=ON \
-  -Droofit=ON \
-  -Droostats=ON \
-  -Dminuit2=ON \
+        -Droofit=ON \
+        -Droostats=ON \
+        -Dminuit2=ON \
 	-Dbuiltin_afterimage=OFF \
 	-Dbuiltin_ftgl=OFF \
 	-Dbuiltin_gl2ps=OFF \

--- a/ubuntu/packages
+++ b/ubuntu/packages
@@ -56,3 +56,5 @@ libxxhash-dev
 libfcgi-dev
 libboost-dev
 wget
+doxygen
+texlive-font-utils

--- a/ubuntu/packages
+++ b/ubuntu/packages
@@ -52,3 +52,7 @@ r-cran-rcpp
 r-cran-rinside
 srm-ifce-dev
 unixodbc-dev
+libxxhash-dev
+libfcgi-dev
+libboost-dev
+wget


### PR DESCRIPTION
This PR updates the Dockerfile and package list of the ROOT ubuntu docker build to ubuntu18, updating some of the package names and CMake options.
Also, a few very commonly used packages have been added to make this container more useful usage as a CI base image for ROOT-based projects.