### PR TITLE
Update Ubuntu to 20.04

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
-ENV ROOT_PROJECT "https://github.com/root-project/root"
+ENV ROOT_FOLDER "/usr/src/root"
+ENV ROOT_PROJECT "https://github.com/root-project/root/archive"
 ENV ROOT_VERSION "v6-20-04"
 
 COPY packages packages
@@ -11,11 +12,13 @@ RUN apt-get update -qq \
  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
  && rm -rf /packages /var/lib/apt/lists/*
 
+RUN mkdir -p ${ROOT_FOLDER} \
+ && curl -sSL "${ROOT_PROJECT}/${ROOT_VERSION}.tar.gz" | tar -xzv \
+	--directory ${ROOT_FOLDER} \
+	--strip-components=1
+
 RUN cd /tmp \
- && git clone ${ROOT_PROJECT} /usr/src/root \
-	--branch ${ROOT_VERSION} \
-	--single-branch \
- && cmake /usr/src/root \
+ && cmake ${ROOT_FOLDER} \
 	-Dall=ON \
 	-Dalien=OFF \
 	-Dcuda=OFF \
@@ -48,7 +51,7 @@ RUN cd /tmp \
 	-Dvecgeom=OFF \
  && cmake --build . -- -j$(nproc) \
  && cmake --build . --target install \
- && rm -rf /tmp/* /usr/src/root
+ && rm -rf /tmp/* ${ROOT_FOLDER}
 
 ENV PYTHONPATH /usr/local/lib
 CMD root -b

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 COPY packages packages
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -12,6 +12,8 @@ RUN cd /tmp \
  && git clone https://github.com/root-project/root /usr/src/root \
  && cmake /usr/src/root \
 	-Dall=ON \
+	-Dalien=OFF \
+	-Dcuda=OFF \
 	-Dcxx14=ON \
 	-Dfail-on-missing=ON \
 	-Dgnuinstall=ON \
@@ -37,6 +39,8 @@ RUN cd /tmp \
 	-Drfio=OFF \
 	-Dsapdb=OFF \
 	-Dsrp=OFF \
+	-Dtmva-gpu=OFF \
+	-Dvecgeom=OFF \
  && cmake --build . -- -j$(nproc) \
  && cmake --build . --target install \
  && rm -rf /tmp/* /usr/src/root

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:20.04
 
+ENV ROOT_PROJECT "https://github.com/root-project/root"
+ENV ROOT_VERSION "v6-20-04"
+
 COPY packages packages
 
 RUN apt-get update -qq \
@@ -9,7 +12,9 @@ RUN apt-get update -qq \
  && rm -rf /packages /var/lib/apt/lists/*
 
 RUN cd /tmp \
- && git clone https://github.com/root-project/root /usr/src/root \
+ && git clone ${ROOT_PROJECT} /usr/src/root \
+	--branch ${ROOT_VERSION} \
+	--single-branch \
  && cmake /usr/src/root \
 	-Dall=ON \
 	-Dalien=OFF \

--- a/ubuntu/packages
+++ b/ubuntu/packages
@@ -10,6 +10,7 @@ git
 libafterimage-dev
 libavahi-compat-libdnssd-dev
 libcfitsio-dev
+libfcgi-dev
 libfftw3-dev
 libfreetype6-dev
 libftgl-dev
@@ -31,7 +32,6 @@ libpcre++-dev
 libpng-dev
 libpq-dev
 libpythia8-dev
-libqt4-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev
@@ -41,7 +41,9 @@ libxext-dev
 libxft-dev
 libxml2-dev
 libxpm-dev
+libxxhash-dev
 libz-dev
+libzstd-dev
 locales
 lsb-release
 make

--- a/ubuntu/packages
+++ b/ubuntu/packages
@@ -1,4 +1,5 @@
 cmake
+curl
 davix-dev
 dcap-dev
 fonts-freefont-ttf


### PR DESCRIPTION
This PR aims to bump up the `Ubuntu` version to the recently released 20.04 LTS.

## Changes

### Packages changes:
1. Remove `libqt4-dev`, given that [it is an optional dependency](https://root.cern.ch/build-prerequisites#ubuntu). ([no longer shipped](https://packages.ubuntu.com/search?keywords=libqt4-dev)).
2. Add `libfcgi-dev`, `libxxhash-dev` and `libzstd-dev`, as CMake would complain otherwise.

### Dockerfile changes
1. Base image now pointing to `ubuntu:20.04`.
1. Pin a specific version of [root](https://github.com/root-project/root). Otherwise, you would run into `master` branch instability.

### Compilation changes
1. Disable Alien (`-Dalien` flag).
2. Disable CUDA (`-Dcuda` and `-Dtmva-gpu` flags).
3. Disable VectorGeom (`-Dvecgeom` flag).

[ROOT forum reference followed](https://root-forum.cern.ch/t/feedback-on-docker-image-provided/35301).


## Final comments
Docker build currently fails when compiling ROOT, at around 70%. The message is:
> Error: open CFI at the end of file; missing .cfi_endproc directory
> c++: fatal error: Killed signal terminated program cc1plus



