### PR TITLE
Use CMD ["root", "-b"] consistently across all images

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -43,5 +43,4 @@ RUN sed -i 's/#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
 # go back to regular user
 USER docker-user
 
-# run bash at login
-CMD ["/bin/bash"]
+CMD ["root", "-b"]

--- a/cc7/Dockerfile
+++ b/cc7/Dockerfile
@@ -8,4 +8,4 @@ RUN yum update -q -y \
  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
  && rm -f /packages
 
-CMD root -b
+CMD ["root", "-b"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -44,4 +44,4 @@ RUN cd /tmp \
  && rm -rf /usr/src/root /tmp/*
 
 ENV PYTHONPATH /usr/local/lib
-CMD root -b
+CMD ["root", "-b"]

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -8,4 +8,4 @@ RUN dnf update -y \
  && dnf install -y $(cat packages) \
  && rm /packages
 
-CMD root.exe
+CMD ["root", "-b"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -8,4 +8,4 @@ COPY portage /etc/portage
 RUN emerge -NDuvt sci-physics/root \
  && rm -rf /tmp/* /usr/portage /var/tmp/portage
 
-CMD /bin/bash -l
+CMD ["root", "-b"]


### PR DESCRIPTION
This is the preferred form according to https://docs.docker.com/engine/reference/builder/#cmd .