### PR TITLE
[doc] Update the command to launch the container with graphics on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Restart Xming and start the container with the following command:
 
 ##### Linux
 To use graphics, make sure you are in an X11 session and run the following command: 
-`docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --rm -it --user $(id -u) rootproject/root`
+`docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --rm -it --user $(id -u) rootproject/root root`
 
 ##### OSX
 To use graphics on OSX, make sure [XQuarz](https://www.xquartz.org/) is installed. After installing, open XQuartz, and go to XQuartz, Preferences, select the Security tab, and tick the box "Allow connections from network clients". Then exit XQuarz. Afterwards, open a terminal and run the following commands:


### PR DESCRIPTION
Since the default image dockerfile uses

```dockerfile
CMD ["root", "-b"]
```

in order to launch the root container with graphics enabled
it is necessary not to pass the batch argument to the root executable, 
which is achieved using the `--entrypoint root` argument of `docker run`.

I have tested the command on Linux, but I guess a similar
change will be needed for OSX too.