### PR TITLE
Use an entrypoint to properly start the conda based image

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/miniforge3
+FROM condaforge/mambaforge
 
 LABEL maintainer.name="ROOT team"
 LABEL maintainer.email="root-dev@cern.ch"
@@ -6,10 +6,14 @@ LABEL maintainer.email="root-dev@cern.ch"
 ARG ROOT_VERSION=6.24.00
 ARG PYTHON_VERSION=3.9
 
+COPY entry_point.sh /
+
 RUN apt-get update && apt-get install --yes libglu1-mesa-dev freeglut3-dev mesa-common-dev && apt-get clean && \
     conda config --set allow_softlinks false && \
     conda config --set always_copy true && \
     conda install --yes --quiet python=$PYTHON_VERSION root=$ROOT_VERSION && \
-    conda clean --yes --all --force-pkgs-dirs
+    conda clean --yes --all --force-pkgs-dirs && \
+    chmod +x /entry_point.sh
 
+ENTRYPOINT ["/entry_point.sh"]
 CMD ["root", "-b"]

--- a/conda/entry_point.sh
+++ b/conda/entry_point.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+. /opt/conda/etc/profile.d/conda.sh && conda activate base
+exec "$@"


### PR DESCRIPTION
Currently the conda based image for 6.24.00 is broken with this message:

```
$ docker run --rm -it rootproject/root:6.24.00-conda
root.exe: /home/conda/feedstock_root/build_artifacts/root_base_1618934087320/work/root-source/interpreter/cling/lib/Interpreter/CIFactory.cpp:595: {anonymous}::collectModuleMaps(clang::CompilerInstance&, llvm::SmallVectorImpl<std::__cxx11::basic_string<char> >&)::<lambda(llvm::StringRef, const string&, const string&, std::string&, bool, bool)>: Assertion `llvm::sys::fs::exists(SystemDir) && "Must exist!"' failed.
```

This is because the environment isn't being activated properly so the `CONDA_BUILD_SYSROOT` environment variable isn't set. Previously the builds were tolerant of this but it seems I've lost a conda-specific patch as part of the LLVM 9 update. I'll fix it in the conda package as well but regardless it's more correct to set up the environment properly.