### PR TITLE
Update README.md: Add --web=off for graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `-v` option tells Docker to mount the home directory (`~`) to `/userhome` in
 To use graphics, make sure you are in an X11 session and run the following command:
 
 ```
-docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --rm -it --user $(id -u) rootproject/root root
+docker run -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --rm -it --user $(id -u) rootproject/root bash -c 'root -l --web=off'
 ```
 
 On some platforms (e.g., Arch Linux) connections to the X server must be allowed explicitly by executing `xhost local:root` or an equivalent command (see e.g. [this page](https://wiki.archlinux.org/index.php/Xhost) for more information on `xhost` and its possible security implications).
@@ -83,7 +83,7 @@ xhost + $ip
 ```
 This will start XQuartz and whitelist your local IP address. Finally, you can start up ROOT with the following command:
 ```
-docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$ip:0 rootproject/root root
+docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$ip:0 rootproject/root bash -c 'root -l --web=off'
 ```
 
 ##### Windows


### PR DESCRIPTION
## Trouble 

My machine prints out the following message when I executed the suggested command, `docker run -it -v ${PWD}:/home/${USERNAME} -e DISPLAY=host.docker.internal:0 rootproject/root:latest root`,  under `Enabling Graphics` at [README.md](https://github.com/root-project/root-docker/blob/master/README.md):

```
Find more info on https://root.cern/for_developers/root7/#rbrowser
Info in <THttpEngine::Create>: Starting HTTP server on port 127.0.0.1:9642

ROOT web-based widget started in the session where DISPLAY set to host.docker.internal:0
Means web browser will be displayed on remote X11 server which is usually very inefficient
One can start ROOT session in server mode like "root -b --web=server:8877" and forward http port to display node
Or one can use rootssh script to configure port forwarding and display web widgets automatically
Find more info on https://root.cern/for_developers/root7/#rbrowser
This message can be disabled by setting "WebGui.CheckRemoteDisplay: no" in .rootrc file
sh: 1: xdg-open: not found
```

## Solution

This can be avoided by updating the `root` with `bash -c 'root -l --web=off'.